### PR TITLE
Study group on item click listener

### DIFF
--- a/app/src/main/java/study_dev/testbed/studyhopper/models/Member.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/models/Member.java
@@ -7,6 +7,7 @@ public class Member {
     private String firstName;
     private String lastName;
     private String userDocId;
+    private String userGroupDocId;
     private String screenName;
     private boolean isOwner;
     private Timestamp whenJoined;
@@ -15,11 +16,12 @@ public class Member {
         // empty constructor needed
     }
 
-    public Member(String firstName, String lastName, String userDocId, String screenName,
+    public Member(String firstName, String lastName, String userDocId, String userGroupDocId, String screenName,
                   boolean isOwner, Timestamp whenJoined) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.userDocId = userDocId;
+        this.userGroupDocId = userGroupDocId;
         this.screenName = screenName;
         this.isOwner = isOwner;
         this.whenJoined = whenJoined;
@@ -37,11 +39,15 @@ public class Member {
         return userDocId;
     }
 
+    public String getUserGroupDocId() {
+        return userGroupDocId;
+    }
+
     public String getScreenName(){
         return screenName;
     }
 
-    public boolean isOwner() {
+    public boolean getIsOwner() {
         return isOwner;
     }
 
@@ -61,9 +67,13 @@ public class Member {
         this.userDocId = userDocId;
     }
 
+    public void setUserGroupDocId(String userGroupDocId) {
+        this.userGroupDocId = userGroupDocId;
+    }
+
     public void setScreenName(String screenName){ this.screenName = screenName; }
 
-    public void setOwner(boolean owner) {
+    public void setIsOwner(boolean owner) {
         isOwner = owner;
     }
 

--- a/app/src/main/java/study_dev/testbed/studyhopper/models/Member.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/models/Member.java
@@ -7,6 +7,7 @@ public class Member {
     private String firstName;
     private String lastName;
     private String userDocId;
+    private String screenName;
     private boolean isOwner;
     private Timestamp whenJoined;
 
@@ -14,11 +15,12 @@ public class Member {
         // empty constructor needed
     }
 
-    public Member(String firstName, String lastName, String userDocId, boolean isOwner,
-                  Timestamp whenJoined) {
+    public Member(String firstName, String lastName, String userDocId, String screenName,
+                  boolean isOwner, Timestamp whenJoined) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.userDocId = userDocId;
+        this.screenName = screenName;
         this.isOwner = isOwner;
         this.whenJoined = whenJoined;
     }
@@ -33,6 +35,10 @@ public class Member {
 
     public String getUserDocId() {
         return userDocId;
+    }
+
+    public String getScreenName(){
+        return screenName;
     }
 
     public boolean isOwner() {
@@ -54,6 +60,8 @@ public class Member {
     public void setUserDocId(String userDocId) {
         this.userDocId = userDocId;
     }
+
+    public void setScreenName(String screenName){ this.screenName = screenName; }
 
     public void setOwner(boolean owner) {
         isOwner = owner;

--- a/app/src/main/java/study_dev/testbed/studyhopper/models/Member.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/models/Member.java
@@ -1,0 +1,65 @@
+package study_dev.testbed.studyhopper.models;
+
+import com.google.firebase.Timestamp;
+
+public class Member {
+
+    private String firstName;
+    private String lastName;
+    private String userDocId;
+    private boolean isOwner;
+    private Timestamp whenJoined;
+
+    public Member(){
+        // empty constructor needed
+    }
+
+    public Member(String firstName, String lastName, String userDocId, boolean isOwner,
+                  Timestamp whenJoined) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.userDocId = userDocId;
+        this.isOwner = isOwner;
+        this.whenJoined = whenJoined;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public String getUserDocId() {
+        return userDocId;
+    }
+
+    public boolean isOwner() {
+        return isOwner;
+    }
+
+    public Timestamp getWhenJoined() {
+        return whenJoined;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public void setUserDocId(String userDocId) {
+        this.userDocId = userDocId;
+    }
+
+    public void setOwner(boolean owner) {
+        isOwner = owner;
+    }
+
+    public void setWhenJoined(Timestamp whenJoined) {
+        this.whenJoined = whenJoined;
+    }
+}

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/CreateGroup.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/CreateGroup.java
@@ -54,7 +54,6 @@ public class CreateGroup extends AppCompatActivity implements View.OnClickListen
     private int colorSelected = 0;
     private ImageView blue, green, yellow, red, purple, orange, brown, gray;
     private Member newMember;
-    private String firstName, lastName;
 
     private FirebaseAuth mAuth = FirebaseAuth.getInstance();
 
@@ -176,21 +175,18 @@ public class CreateGroup extends AppCompatActivity implements View.OnClickListen
                     Log.d(TAG, e.toString());
                 }
                 if (documentSnapshot.exists()) {
-                    firstName  = documentSnapshot.getString("firstName");
-                    lastName  = documentSnapshot.getString("lastName");
+                    String firstName  = documentSnapshot.getString("firstName");
+                    String lastName  = documentSnapshot.getString("lastName");
 
+                    CollectionReference groupMemberRef = FirebaseFirestore.getInstance()
+                            .collection("groups").document(groupId)
+                            .collection("members");
+                    newMember = new Member(firstName, lastName, getUserName(), true,
+                            Timestamp.now());
+                    groupMemberRef.add(newMember);
                 }
             }
         });
-
-        CollectionReference groupMemberRef = FirebaseFirestore.getInstance()
-                .collection("groups").document(groupId)
-                .collection("members");
-//
-        newMember = new Member(firstName, lastName, getUserName(), true,
-                Timestamp.now());
-//
-        groupMemberRef.add(newMember);
 
         Toast.makeText(this, "Group added", Toast.LENGTH_SHORT).show();
         finish();

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/CreateGroup.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/CreateGroup.java
@@ -181,7 +181,7 @@ public class CreateGroup extends AppCompatActivity implements View.OnClickListen
                     CollectionReference groupMemberRef = FirebaseFirestore.getInstance()
                             .collection("groups").document(groupId)
                             .collection("members");
-                    newMember = new Member(firstName, lastName, getUserName(), true,
+                    newMember = new Member(firstName, lastName, getUserName(), getUserName(), true,
                             Timestamp.now());
                     groupMemberRef.add(newMember);
                 }

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/DashboardFragment.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/DashboardFragment.java
@@ -183,7 +183,8 @@ public class DashboardFragment extends Fragment {
     @Override
     public void onStart() {
         super.onStart();
-
+        if(adapter != null)
+            adapter.startListening();
     }
 
 

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/DashboardFragment.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/DashboardFragment.java
@@ -33,6 +33,7 @@ import study_dev.testbed.studyhopper.R;
 import study_dev.testbed.studyhopper.StudyRoomReservations;
 import study_dev.testbed.studyhopper.models.Group;
 import study_dev.testbed.studyhopper.ui.groupFinder.StudyGroupFinder;
+import study_dev.testbed.studyhopper.ui.studyGroup.StudyGroupActivity;
 
 
 public class DashboardFragment extends Fragment {
@@ -104,11 +105,14 @@ public class DashboardFragment extends Fragment {
         adapter.setOnItemClickListener(new GroupAdapter.OnItemClickListener() {
             @Override
             public void onItemClick(DocumentSnapshot documentSnapshot, int position) {
-                Group group = documentSnapshot.toObject(Group.class);
-                String path = documentSnapshot.getReference().getPath();
                 String id = documentSnapshot.getId();
                 Toast.makeText(getContext(),
                         "Position: " + position + " ID: " + id, Toast.LENGTH_SHORT).show();
+                Activity activity = (Activity) getContext();
+                Intent intent = new Intent(getContext(), StudyGroupActivity.class);
+                intent.putExtra("documentID", id);
+                startActivity(intent);
+                activity.overridePendingTransition(0, 0);
             }
         });
 

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/DashboardFragment.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/DashboardFragment.java
@@ -57,12 +57,8 @@ public class DashboardFragment extends Fragment {
 
     private FirebaseAuth mAuth = FirebaseAuth.getInstance();
     private FirebaseFirestore db = FirebaseFirestore.getInstance();
-    private DocumentReference docRef = db.collection("users").document(getUserName());
     private CollectionReference userRef = db.collection("users");
     private CollectionReference groupRef;
-
-//    private CollectionReference groupRef = db.collection("users")
-//            .document(getUserName()).collection("groups");
 
     @SuppressLint("SetTextI18n")
     @Nullable
@@ -182,13 +178,6 @@ public class DashboardFragment extends Fragment {
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(adapter);
         adapter.startListening();
-    }
-
-
-    private String getUserName() {
-        String email = mAuth.getCurrentUser().getEmail();
-        int parseIndex = email.indexOf('@');
-        return email.substring(0, parseIndex);
     }
 
     @Override

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/MyGroups.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/MyGroups.java
@@ -39,7 +39,7 @@ public class MyGroups extends AppCompatActivity {
     private CollectionReference groupRef;
     private CollectionReference ref = db.collection("groups");
 
-    private GroupAdapter adapter;
+    protected static GroupAdapter adapter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -108,16 +108,20 @@ public class MyGroups extends AppCompatActivity {
         RecyclerView recyclerView = findViewById(R.id.group_recycler_view);
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        recyclerView.setAdapter(adapter);
         adapter.startListening();
+        recyclerView.setAdapter(adapter);
     }
 
 
-//    @Override
-//    protected void onStart() {
-//        super.onStart();
-//
-//    }
+
+
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if(adapter != null)
+            adapter.startListening();
+    }
 
 //    @Override
 //    protected void onResume() {

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/MyGroups.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/dashboard/MyGroups.java
@@ -122,10 +122,6 @@ public class MyGroups extends AppCompatActivity {
                 overridePendingTransition(0, 0);
                 return true;
 
-            case R.id.search_group_option:
-                // TODO implement search for group activity
-                return true;
-
             default:
                 return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/GroupMemberList.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/GroupMemberList.java
@@ -116,8 +116,8 @@ public class GroupMemberList extends AppCompatActivity {
                                         String fName = tempProfile.getFirstName();
                                         String lName = tempProfile.getLastName();
 
-                                        final Member newMember = new Member(fName, lName
-                                                , getUsername(memberEmail), false, Timestamp.now());
+                                        final Member newMember = new Member(fName, lName, getUsername(memberEmail),
+                                                getUsername(memberEmail), false, Timestamp.now());
 
                                         groupMemberRef.whereEqualTo("userDocId", getUsername(memberEmail))
                                                 .get()

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/GroupMemberList.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/GroupMemberList.java
@@ -1,25 +1,100 @@
 package study_dev.testbed.studyhopper.ui.studyGroup;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.View;
+import android.widget.EditText;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import study_dev.testbed.studyhopper.R;
 
 public class GroupMemberList extends AppCompatActivity {
+    private String userGroupDocID;
+    private String groupDocID;
+
+    private EditText memberCandidateEditText;
+    private FirebaseAuth auth = FirebaseAuth.getInstance();
+    private FirebaseFirestore db = FirebaseFirestore.getInstance();
+    private CollectionReference usersRef = db.collection("users");
+    private String emailRegex = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^-]+(?:\\.[a-zA-Z0-9_!#$%&'*+/=?`{|}~^-]+)*@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$";
+    private Pattern emailPattern = Pattern.compile(emailRegex);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_group_members_list);
 
+        Intent intent = getIntent();
+        userGroupDocID = intent.getStringExtra("userDocId");
+
+
         // Enable back button
         ActionBar supportActionBar = getSupportActionBar();
         if (supportActionBar != null) {
             supportActionBar.setDisplayHomeAsUpEnabled(true);
         }
+    }
+
+    public void addGroupMember(View v){
+        View addMemberView = getLayoutInflater().inflate(R.layout.dialog_add_member, null);
+        memberCandidateEditText = addMemberView.findViewById(R.id.edit_member);
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setView(addMemberView);
+        builder.setTitle("Add Member");
+        builder.setPositiveButton("Done", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                // Leave empty will override in onClickListener
+            }
+        });
+
+        builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+
+            }
+        });
+
+        final AlertDialog addMemberDialog = builder.create();
+        addMemberDialog.show();
+
+        addMemberDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Boolean closeDialog = false;
+
+                String memberEmail = memberCandidateEditText.getText().toString();
+
+                Matcher matcher = emailPattern.matcher(memberEmail.trim());
+
+                if(!matcher.matches()){
+                    memberCandidateEditText.setError("Invalid email!");
+                }
+                else
+                    closeDialog = true;
+
+                if(closeDialog)
+                    addMemberDialog.dismiss();
+            }
+        });
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.group_members_list_menu, menu);
+        return super.onCreateOptionsMenu(menu);
     }
 
     @Override
@@ -32,7 +107,19 @@ public class GroupMemberList extends AppCompatActivity {
     public void onBackPressed() {
 
         Intent in = new Intent(getBaseContext(), StudyGroupActivity.class);
+        in.putExtra("documentID", userGroupDocID);
         startActivity(in);
         overridePendingTransition(0, 0);
+    }
+
+    private String getUserName() {
+        String email = auth.getCurrentUser().getEmail();
+        int parseIndex = email.indexOf('@');
+        return email.substring(0, parseIndex);
+    }
+
+    private String getUsername(String email) {
+        int parseIndex = email.indexOf('@');
+        return email.substring(0, parseIndex);
     }
 }

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/GroupMemberList.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/GroupMemberList.java
@@ -224,7 +224,7 @@ public class GroupMemberList extends AppCompatActivity {
                                                 if(documentSnapshot.exists())
                                                 {
                                                    final Member member = documentSnapshot.toObject(Member.class);
-                                                    if(!member.isOwner()) {
+                                                    if(!member.getIsOwner()) {
                                                         adapter.deleteItem(position);
 
                                                         Query findMemberToDelete = db.collection("users").document(member.getUserDocId()).collection("groups").
@@ -345,7 +345,7 @@ public class GroupMemberList extends AppCompatActivity {
                                 String lName = tempProfile.getLastName();
                                 String userName = getUsername(memberEmail);
 
-                                final Member newMember = new Member(fName, lName, memberDocId,
+                                final Member newMember = new Member(fName, lName, memberDocId, userGroupDocID,
                                         userName, false, Timestamp.now());
 
                                 groupMemberRef.whereEqualTo("userDocId", memberDocId)
@@ -417,12 +417,6 @@ public class GroupMemberList extends AppCompatActivity {
         in.putExtra("documentID", userGroupDocID);
         startActivity(in);
         overridePendingTransition(0, 0);
-    }
-
-    private String getUserName() {
-        String email = auth.getCurrentUser().getEmail();
-        int parseIndex = email.indexOf('@');
-        return email.substring(0, parseIndex);
     }
 
     private String getUsername(String email) {

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
@@ -1,0 +1,60 @@
+package study_dev.testbed.studyhopper.ui.studyGroup;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.firebase.ui.firestore.FirestoreRecyclerAdapter;
+import com.firebase.ui.firestore.FirestoreRecyclerOptions;
+
+import study_dev.testbed.studyhopper.R;
+import study_dev.testbed.studyhopper.models.Member;
+
+public class MemberAdapter extends FirestoreRecyclerAdapter<Member, MemberAdapter.MemberHolder> {
+
+    public MemberAdapter(@NonNull FirestoreRecyclerOptions<Member> options) {
+        super(options);
+        // Do not delete
+    }
+
+    @Override
+    protected void onBindViewHolder(@NonNull MemberHolder holder, int position, @NonNull Member model) {
+        holder.textViewName.setText(model.getFirstName() + " " + model.getLastName());
+        holder.screenName.setText(model.getScreenName());
+        if(model.isOwner())
+        {
+            holder.imageViewGroupOwner.setImageResource(R.drawable.ic_group_leader);
+        }
+    }
+
+    @NonNull
+    @Override
+    public MemberHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.member_item,
+                parent, false);
+
+        return new MemberHolder(v);
+    }
+
+
+    class MemberHolder extends RecyclerView.ViewHolder {
+        ImageView imageViewProfile;
+        TextView textViewName;
+        TextView screenName;
+        ImageView imageViewGroupOwner;
+
+        public MemberHolder(@NonNull View itemView) {
+            super(itemView);
+            imageViewProfile = itemView.findViewById(R.id.image_view_user_photo);
+            textViewName = itemView.findViewById(R.id.text_view_username);
+            screenName = itemView.findViewById(R.id.text_view_screen_name);
+            imageViewGroupOwner = itemView.findViewById(R.id.image_view_group_owner);
+
+        }
+    }
+}

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
@@ -11,11 +11,13 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.firebase.ui.firestore.FirestoreRecyclerAdapter;
 import com.firebase.ui.firestore.FirestoreRecyclerOptions;
+import com.google.firebase.firestore.DocumentSnapshot;
 
 import study_dev.testbed.studyhopper.R;
 import study_dev.testbed.studyhopper.models.Member;
 
 public class MemberAdapter extends FirestoreRecyclerAdapter<Member, MemberAdapter.MemberHolder> {
+    private OnItemClickListener listener;
 
     public MemberAdapter(@NonNull FirestoreRecyclerOptions<Member> options) {
         super(options);
@@ -41,6 +43,12 @@ public class MemberAdapter extends FirestoreRecyclerAdapter<Member, MemberAdapte
         return new MemberHolder(v);
     }
 
+    public void deleteItem(int position) {
+        getSnapshots().getSnapshot(position).getReference().delete();
+    }
+
+
+
 
     class MemberHolder extends RecyclerView.ViewHolder {
         ImageView imageViewProfile;
@@ -55,6 +63,25 @@ public class MemberAdapter extends FirestoreRecyclerAdapter<Member, MemberAdapte
             screenName = itemView.findViewById(R.id.text_view_screen_name);
             imageViewGroupOwner = itemView.findViewById(R.id.image_view_group_owner);
 
+            itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    int position = getAdapterPosition();
+                    if(position != RecyclerView.NO_POSITION && listener != null) {
+                        listener.onItemClick(getSnapshots().getSnapshot(position), position);
+                    }
+                }
+            });
+
         }
     }
+
+    public interface  OnItemClickListener {
+        void onItemClick(DocumentSnapshot documentSnapshot, int position);
+    }
+
+    public void setOnItemClickListener(OnItemClickListener listener) {
+        this.listener = listener;
+    }
+
 }

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
@@ -28,7 +28,7 @@ public class MemberAdapter extends FirestoreRecyclerAdapter<Member, MemberAdapte
     protected void onBindViewHolder(@NonNull MemberHolder holder, int position, @NonNull Member model) {
         holder.textViewName.setText(model.getFirstName() + " " + model.getLastName());
         holder.screenName.setText(model.getScreenName());
-        if(model.isOwner())
+        if(model.getIsOwner())
         {
             holder.imageViewGroupOwner.setImageResource(R.drawable.ic_group_leader);
         }

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/MemberAdapter.java
@@ -47,6 +47,10 @@ public class MemberAdapter extends FirestoreRecyclerAdapter<Member, MemberAdapte
         getSnapshots().getSnapshot(position).getReference().delete();
     }
 
+    public String getDocId(int position) {
+        return getSnapshots().getSnapshot(position).getReference().getId();
+    }
+
 
 
 

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/StudyGroupActivity.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/StudyGroupActivity.java
@@ -91,7 +91,7 @@ public class StudyGroupActivity extends AppCompatActivity {
                     templateGroup = documentSnapshot.toObject(Group.class);
 
                     groupNameTextView.setText(templateGroup.getGroupName());
-                    courseCodeTextView.setText(templateGroup.getGroupName());
+                    courseCodeTextView.setText(templateGroup.getCourseCode());
                     groupColorImageView.setImageResource(findGroupColorId(templateGroup.getGroupColor()));
 
                     Query groupQuery = groupRef.whereEqualTo("groupName", templateGroup.getGroupName());

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/StudyGroupActivity.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/StudyGroupActivity.java
@@ -110,7 +110,7 @@ public class StudyGroupActivity extends AppCompatActivity {
                 }
 
                 else {
-                    groupNameTextView.setText("Problem!");
+                    groupNameTextView.setText("Error!");
                     courseCodeTextView.setText("N/A");
                     groupColorImageView.setImageResource(findGroupColorId("Gray"));
                 }
@@ -118,26 +118,6 @@ public class StudyGroupActivity extends AppCompatActivity {
         });
 
         String user = getUserName();
-//        String groupName = templateGroup.getGroupName();
-
-
-
-
-//        Intent intent = getIntent();
-//        studyGroupItem = intent.getParcelableExtra("Study Group Item");
-
-//        int imageRes = studyGroupItem.getImageResource();
-//        String line1 = studyGroupItem.getText1();
-//        String line2 = studyGroupItem.getText2();
-
-
-//        imageView.setImageResource(imageRes);
-//
-//        TextView textView1 = findViewById(R.id.groupName);
-//        textView1.setText(line1);
-//
-//        TextView textView2 = findViewById(R.id.groupCourseCode);
-//        textView2.setText(line2);
 
         // Enable back button
         ActionBar supportActionBar = getSupportActionBar();
@@ -162,6 +142,8 @@ public class StudyGroupActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(StudyGroupActivity.this, GroupMemberList.class);
+                intent.putExtra("userDocId", docID);
+                intent.putExtra("groupDocId", groupID);
                 startActivity(intent);
                 overridePendingTransition(0, 0);
             }

--- a/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/StudyGroupActivity.java
+++ b/app/src/main/java/study_dev/testbed/studyhopper/ui/studyGroup/StudyGroupActivity.java
@@ -93,6 +93,20 @@ public class StudyGroupActivity extends AppCompatActivity {
                     groupNameTextView.setText(templateGroup.getGroupName());
                     courseCodeTextView.setText(templateGroup.getGroupName());
                     groupColorImageView.setImageResource(findGroupColorId(templateGroup.getGroupColor()));
+
+                    Query groupQuery = groupRef.whereEqualTo("groupName", templateGroup.getGroupName());
+
+                    groupQuery.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                        @Override
+                        public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                            if(task.isSuccessful()) {
+                                for(QueryDocumentSnapshot document : task.getResult()) {
+                                    groupID = document.getId();
+                                    Toast.makeText(StudyGroupActivity.this, "Doc ID: " + groupID, Toast.LENGTH_SHORT).show();
+                                }
+                            }
+                        }
+                    });
                 }
 
                 else {
@@ -103,20 +117,10 @@ public class StudyGroupActivity extends AppCompatActivity {
             }
         });
 
-        Query groupQuery = groupRef.whereEqualTo("groupName", "Ethics Final Project")
-                .whereEqualTo("groupOwner", "mkaburis");
+        String user = getUserName();
+//        String groupName = templateGroup.getGroupName();
 
-        groupQuery.get().addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
-            @Override
-            public void onComplete(@NonNull Task<QuerySnapshot> task) {
-                if(task.isSuccessful()) {
-                    for(QueryDocumentSnapshot document : task.getResult()) {
-                        groupID = document.getId();
-                        Toast.makeText(StudyGroupActivity.this, "Doc ID: " + groupID, Toast.LENGTH_SHORT).show();
-                    }
-                }
-            }
-        });
+
 
 
 //        Intent intent = getIntent();

--- a/app/src/main/res/drawable/ic_add_group_member.xml
+++ b/app/src/main/res/drawable/ic_add_group_member.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M15,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM6,10L6,7L4,7v3L1,10v2h3v3h2v-3h3v-2L6,10zM15,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_group_leader.xml
+++ b/app/src/main/res/drawable/ic_group_leader.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#1866CD"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/activity_group_members_list.xml
+++ b/app/src/main/res/layout/activity_group_members_list.xml
@@ -1,8 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/addMemberFAB"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.studyGroup.GroupMemberList">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="10dp"
+        android:backgroundTint="@color/safariGreen"
+        android:src="@drawable/ic_add"
+        android:onClick="addGroupMember"
+        app:borderWidth="0dp" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/member_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="680dp"
+        android:scrollbars="vertical"/>
+
+    <TextView
+        android:id="@+id/text_view_num_members"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/member_recycler_view"
+        android:textSize="25sp"
+        android:gravity="center" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_group_members_list.xml
+++ b/app/src/main/res/layout/activity_group_members_list.xml
@@ -21,7 +21,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/member_recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="680dp"
+        android:layout_height="match_parent"
         android:scrollbars="vertical"/>
 
     <TextView

--- a/app/src/main/res/layout/activity_study_group.xml
+++ b/app/src/main/res/layout/activity_study_group.xml
@@ -10,13 +10,11 @@
         android:id="@+id/messageFAB"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
+        android:layout_margin="10dp"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
         android:src="@drawable/ic_chat_icon"
-        android:contentDescription="@string/messages"
-        />
-
+        android:contentDescription="@string/messages" />
 
     <RelativeLayout
         android:id="@+id/group_name_layout"

--- a/app/src/main/res/layout/dialog_add_member.xml
+++ b/app/src/main/res/layout/dialog_add_member.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/edit_member"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/group_member_edit_text_hint"
+        android:inputType="textEmailAddress" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/member_card.xml
+++ b/app/src/main/res/layout/member_card.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:layout_marginStart="5dp"
+    android:layout_marginEnd="5dp"
+    card_view:cardCornerRadius="4dp"
+    card_view:cardElevation="6dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:padding="5dp">
+
+        <ImageView
+            android:id="@+id/image_view_user_photo"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="10dp"
+            android:layout_centerVertical="true"
+            android:src="@mipmap/ic_profile_image_round"/>
+
+        <TextView
+            android:id="@+id/text_view_username"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_toEndOf="@id/image_view_user_photo"
+            android:layout_marginEnd="20dp"
+            android:text="Line 1"
+            android:maxLines="1"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            android:textColor="@android:color/black"/>
+
+        <TextView
+            android:id="@+id/text_view_course_code"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/text_view_username"
+            android:layout_toEndOf="@id/image_view_user_photo"
+            android:layout_marginStart="18dp"
+            android:layout_marginEnd="20dp"
+            android:text="Line 2"
+            android:textSize="15sp"/>
+
+
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/member_card.xml
+++ b/app/src/main/res/layout/member_card.xml
@@ -5,10 +5,11 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="8dp"
-    android:layout_marginStart="5dp"
-    android:layout_marginEnd="5dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
     card_view:cardCornerRadius="4dp"
-    card_view:cardElevation="6dp">
+    card_view:cardElevation="6dp"
+    card_view:cardBackgroundColor="#F5F5F5">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -20,7 +21,8 @@
             android:id="@+id/image_view_user_photo"
             android:layout_width="60dp"
             android:layout_height="60dp"
-            android:layout_marginStart="10dp"
+            android:layout_marginStart="12dp"
+            android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
             android:src="@mipmap/ic_profile_image_round"/>
 
@@ -48,6 +50,12 @@
             android:text="Line 2"
             android:textSize="15sp"/>
 
+        <ImageView
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="20dp" />
 
 
     </RelativeLayout>

--- a/app/src/main/res/layout/member_item.xml
+++ b/app/src/main/res/layout/member_item.xml
@@ -30,9 +30,8 @@
             android:id="@+id/text_view_username"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="10dp"
+            android:layout_marginStart="22dp"
             android:layout_toEndOf="@id/image_view_user_photo"
-            android:layout_marginEnd="20dp"
             android:text="Line 1"
             android:maxLines="1"
             android:textSize="20sp"
@@ -40,17 +39,17 @@
             android:textColor="@android:color/black"/>
 
         <TextView
-            android:id="@+id/text_view_course_code"
+            android:id="@+id/text_view_screen_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/text_view_username"
             android:layout_toEndOf="@id/image_view_user_photo"
-            android:layout_marginStart="18dp"
-            android:layout_marginEnd="20dp"
+            android:layout_marginStart="22dp"
             android:text="Line 2"
             android:textSize="15sp"/>
 
         <ImageView
+            android:id="@+id/image_view_group_owner"
             android:layout_width="30dp"
             android:layout_height="30dp"
             android:layout_alignParentEnd="true"

--- a/app/src/main/res/menu/group_members_list_menu.xml
+++ b/app/src/main/res/menu/group_members_list_menu.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+</menu>

--- a/app/src/main/res/menu/group_members_list_menu.xml
+++ b/app/src/main/res/menu/group_members_list_menu.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/create_group_option"
+        android:icon="@drawable/ic_add_group"
+        android:title="@string/create_study_group"
+        app:showAsAction="ifRoom"/>
 
 </menu>

--- a/app/src/main/res/menu/group_members_list_menu.xml
+++ b/app/src/main/res/menu/group_members_list_menu.xml
@@ -5,7 +5,6 @@
     <item
         android:id="@+id/create_group_option"
         android:icon="@drawable/ic_add_group"
-        android:title="@string/create_study_group"
-        app:showAsAction="ifRoom"/>
+        android:title="@string/remove_members" />
 
 </menu>

--- a/app/src/main/res/menu/my_groups_menu.xml
+++ b/app/src/main/res/menu/my_groups_menu.xml
@@ -5,13 +5,7 @@
     <item
         android:id="@+id/create_group_option"
         android:icon="@drawable/ic_add_group"
-        android:title="@string/create_study_group"
-        app:showAsAction="ifRoom"/>
-
-    <item
-        android:id="@+id/search_group_option"
-        android:icon="@drawable/ic_finder_icon"
-        android:title="@string/study_group_add_session"
+        android:title="@string/add_group_member"
         app:showAsAction="ifRoom"/>
 
 </menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,4 +4,9 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding">16dp</dimen>
+    <dimen name="activity_padding_horizontal">16dp</dimen>
+    <dimen name="padd_10">10dp</dimen>
+    <dimen name="ic_delete">30dp</dimen>
+    <dimen name="thumbnail">90dp</dimen>
 </resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,5 +89,6 @@
     <string name="forgot_password_button_text">Forgot Password</string>
     <string name="add_group_member">Add Group Member</string>
     <string name="group_member_edit_text_hint">Type in an email address</string>
+    <string name="remove_members">Remove Members</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,5 @@
     <string name="group_member_edit_text_hint">Type in an email address</string>
     <string name="remove_members">Remove Members</string>
 
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,4 +87,7 @@
     <string name="ex_course_section">01</string>
     <string name="remove_button_desc">Button to remove class</string>
     <string name="forgot_password_button_text">Forgot Password</string>
+    <string name="add_group_member">Add Group Member</string>
+    <string name="group_member_edit_text_hint">Type in an email address</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="add_group_member">Add Group Member</string>
     <string name="group_member_edit_text_hint">Type in an email address</string>
     <string name="remove_members">Remove Members</string>
+    <string name ="delete">Delete</string>
 
 
 </resources>


### PR DESCRIPTION
_Warning_ There are likely merge conflicts with this pull request due to its nature.

Completed adding functionality for Group Members activity:

- [ ] Users can review all of the group members within their specific group. A special 'star' indication is used for the group owner.
- [ ] Users can add group members using an email address for the user they want to add.
- [ ] Users can remove members from the group. They are first prompted with a confirmation to prevent deletion mistakes.
- [ ] Verification for adding a group member has been added. Invalid emails, existing group members, and emails that are not associated with accounts cannot be added to the group. Adding a group member past the maximum group size is also prohibited.

Possible future enhancements:

- [ ] Displaying the group size at the bottom of the activity.
- [ ] An undo functionality for deleting a group member (this is a bit complex given the way we add group members in Firebase). 

Closes Issue #37 